### PR TITLE
Pass the shared_preload_libraries to postgres via `-c` argument.

### DIFF
--- a/gpAux/gpdemo/demo_cluster.sh
+++ b/gpAux/gpdemo/demo_cluster.sh
@@ -396,10 +396,6 @@ fi
 # Add fsync=off for all gpdemo deployments
 grep -q 'fsync=off' ${CLUSTER_CONFIG_POSTGRES_ADDONS} && echo "fsync=off already exists in ${CLUSTER_CONFIG_POSTGRES_ADDONS}." || echo "fsync=off" >> ${CLUSTER_CONFIG_POSTGRES_ADDONS}
 
-if [ ! -z "${GP_PRELOAD_LIBRARIES}" ]; then
-	echo "shared_preload_libraries=${GP_PRELOAD_LIBRARIES}" >> ${CLUSTER_CONFIG_POSTGRES_ADDONS}
-fi
-
 echo ""
 echo "======================================================================"
 echo "CLUSTER_CONFIG_POSTGRES_ADDONS: ${CLUSTER_CONFIG_POSTGRES_ADDONS}"
@@ -408,18 +404,12 @@ cat ${CLUSTER_CONFIG_POSTGRES_ADDONS}
 echo "======================================================================"
 echo ""
 
-INITSYSTEMCMD="$GPPATH/gpinitsystem"
-if [ ! -z "${GP_PRELOAD_LIBRARIES}" ]; then
-	INITSYSTEMCMD="$INITSYSTEMCMD --preload-libraries=$GP_PRELOAD_LIBRARIES"
-fi
-INITSYSTEMCMD="$INITSYSTEMCMD -a -c $CLUSTER_CONFIG -l $DATADIRS/gpAdminLogs -p ${CLUSTER_CONFIG_POSTGRES_ADDONS} ${STANDBY_INIT_OPTS} \"$@\""
-
 echo "=========================================================================================="
 echo "executing:"
-echo "  $INITSYSTEMCMD "
+echo "  $GPPATH/gpinitsystem -a -c $CLUSTER_CONFIG -l $DATADIRS/gpAdminLogs -p ${CLUSTER_CONFIG_POSTGRES_ADDONS} ${STANDBY_INIT_OPTS} \"$@\""
 echo "=========================================================================================="
 echo ""
-$INITSYSTEMCMD
+$GPPATH/gpinitsystem -a -c $CLUSTER_CONFIG -l $DATADIRS/gpAdminLogs -p ${CLUSTER_CONFIG_POSTGRES_ADDONS} ${STANDBY_INIT_OPTS} "$@"
 RETURN=$?
 
 echo "========================================"

--- a/gpMgmt/bin/gpinitsystem
+++ b/gpMgmt/bin/gpinitsystem
@@ -157,7 +157,7 @@ USAGE () {
 		$ECHO "          postgresql.conf file during Greenplum database initialization."
 		$ECHO "      -P, standby_port [optional]"
 		$ECHO "      -s, standby_hostname [optional]"
-		$ECHO "      --preload-libraries [optional], same as shared_preload_libraries in postgresql.conf"
+		$ECHO "      --shared-preload-libraries [optional], same as shared_preload_libraries in postgresql.conf [defaults to '']"
 		$ECHO
 		$ECHO "      Return codes:"
 		$ECHO "      0 - No problems encountered with requested operation"
@@ -396,6 +396,13 @@ CHK_PARAMS () {
 			if [ $COORDINATOR_MAX_CONNECT -lt 1 ];then
 				ERROR_EXIT "[FATAL]:-COORDINATOR_MAX_CONNECT less than 1"
 			fi
+		fi
+		# SHARED_PRELOAD_LIBRARIES
+		if [ x"" = x"$SHARED_PRELOAD_LIBRARIES" ]; then
+		    LOG_MSG "[INFO]:-SHARED_PRELOAD_LIBRARIES not set, will set to default value $DEFAULT_SHARED_PRELOAD_LIBRARIES" 1
+		    SHARED_PRELOAD_LIBRARIES=$DEFAULT_SHARED_PRELOAD_LIBRARIES
+		else
+		    LOG_MSG "[INFO]:-Server process will load libraries: $SHARED_PRELOAD_LIBRARIES" 1
 		fi
 		((QE_MAX_CONNECT=$COORDINATOR_MAX_CONNECT*$QE_CONNECT_FACTOR))
 		LOG_MSG "[INFO]:-Setting segment instance MAX_CONNECTIONS to $QD_MAX_CONNECT"
@@ -1039,22 +1046,24 @@ DISPLAY_CONFIG () {
 		LOG_MSG "[INFO]:---------------------------------------" 1
 		LOG_MSG "[INFO]:-Coordinator Configuration" 1
 		LOG_MSG "[INFO]:---------------------------------------" 1
-		LOG_MSG "[INFO]:-Coordinator hostname       = $GP_HOSTADDRESS" 1
-		LOG_MSG "[INFO]:-Coordinator port           = $COORDINATOR_PORT" 1
-		LOG_MSG "[INFO]:-Coordinator instance dir   = $GP_DIR" 1
-		LOG_MSG "[INFO]:-Coordinator LOCALE         = $LOCALE_SETTING" 1
-		LOG_MSG "[INFO]:-Greenplum segment prefix   = $SEG_PREFIX" 1
-		LOG_MSG "[INFO]:-Coordinator Database       = $DATABASE_NAME" 1
-		LOG_MSG "[INFO]:-Coordinator connections    = $COORDINATOR_MAX_CONNECT" 1
-		LOG_MSG "[INFO]:-Coordinator buffers        = $COORDINATOR_SHARED_BUFFERS" 1
-		LOG_MSG "[INFO]:-Segment connections        = $QE_MAX_CONNECT" 1
-		LOG_MSG "[INFO]:-Segment buffers            = $QE_SHARED_BUFFERS" 1
-		LOG_MSG "[INFO]:-Encoding                   = $ENCODING" 1
-		LOG_MSG "[INFO]:-Postgres param file        = $PG_ADD" 1
-		LOG_MSG "[INFO]:-Initdb to be used          = $INITDB" 1
-		LOG_MSG "[INFO]:-GP_LIBRARY_PATH is         = $GP_LIBRARY_PATH" 1
-		LOG_MSG "[INFO]:-HEAP_CHECKSUM is           = $HEAP_CHECKSUM" 1
-		LOG_MSG "[INFO]:-HBA_HOSTNAMES is           = $HBA_HOSTNAMES" 1
+		LOG_MSG "[INFO]:-Coordinator hostname                 = $GP_HOSTADDRESS" 1
+		LOG_MSG "[INFO]:-Coordinator port                     = $COORDINATOR_PORT" 1
+		LOG_MSG "[INFO]:-Coordinator instance dir             = $GP_DIR" 1
+		LOG_MSG "[INFO]:-Coordinator LOCALE                   = $LOCALE_SETTING" 1
+		LOG_MSG "[INFO]:-Greenplum segment prefix             = $SEG_PREFIX" 1
+		LOG_MSG "[INFO]:-Coordinator Database                 = $DATABASE_NAME" 1
+		LOG_MSG "[INFO]:-Coordinator connections              = $COORDINATOR_MAX_CONNECT" 1
+		LOG_MSG "[INFO]:-Coordinator buffers                  = $COORDINATOR_SHARED_BUFFERS" 1
+		LOG_MSG "[INFO]:-Coordinator shared preload libraries = $SHARED_PRELOAD_LIBRARIES" 1
+		LOG_MSG "[INFO]:-Segment connections                  = $QE_MAX_CONNECT" 1
+		LOG_MSG "[INFO]:-Segment buffers                      = $QE_SHARED_BUFFERS" 1
+		LOG_MSG "[INFO]:-Segment shared preload libraries     = $SHARED_PRELOAD_LIBRARIES" 1
+		LOG_MSG "[INFO]:-Encoding                             = $ENCODING" 1
+		LOG_MSG "[INFO]:-Postgres param file                  = $PG_ADD" 1
+		LOG_MSG "[INFO]:-Initdb to be used                    = $INITDB" 1
+		LOG_MSG "[INFO]:-GP_LIBRARY_PATH is                   = $GP_LIBRARY_PATH" 1
+		LOG_MSG "[INFO]:-HEAP_CHECKSUM is                     = $HEAP_CHECKSUM" 1
+		LOG_MSG "[INFO]:-HBA_HOSTNAMES is                     = $HBA_HOSTNAMES" 1
 		if [ $ULIMIT_WARN -eq 1 ];then
 			LOG_MSG "[WARN]:-Ulimit check               = Warnings generated, see log file $WARN_MARK" 1
 		else
@@ -1189,9 +1198,7 @@ CREATE_QD_DB () {
 		cmd="$cmd $LC_ALL_SETTINGS"
 		cmd="$cmd --max_connections=$COORDINATOR_MAX_CONNECT"
 		cmd="$cmd --shared_buffers=$COORDINATOR_SHARED_BUFFERS"
-		if [ x"$GP_PRELOAD_LIBRARIES" != x"" ]; then
-			cmd="$cmd --preload-libraries=$GP_PRELOAD_LIBRARIES"
-		fi
+		cmd="$cmd --shared-preload-libraries=$SHARED_PRELOAD_LIBRARIES"
 		if [ x"$HEAP_CHECKSUM" == x"on" ]; then
 			cmd="$cmd --data-checksums"
 		fi
@@ -1355,7 +1362,7 @@ CREATE_SEGMENT () {
 			export QE_MAX_CONNECT
 			export QE_SHARED_BUFFERS
 			export SEG_PREFIX
-			export GP_PRELOAD_LIBRARIES
+			export SHARED_PRELOAD_LIBRARIES
 			if [ $DEBUG_LEVEL -eq 0 ] && [ x"" != x"$VERBOSE" ];then $NOLINE_ECHO ".\c";fi
 				FLAG=""
 			if [ x"" != x"$PG_CONF_ADD_FILE" ] ; then
@@ -1905,7 +1912,7 @@ while getopts ":vaqe:c:l:-:p:m:h:n:s:P:S:b:DB:I:O:" opt
 						"lc-time"           ) LCTIME=$VAL ;;
 						"mirror-mode"       ) SET_MIRROR_MODE $VAL ;;
 						"standby-datadir"   ) STANDBY_DATADIR=$VAL ;;
-						"preload-libraries" ) GP_PRELOAD_LIBRARIES=$VAL ;;
+						"shared-preload-libraries" ) SHARED_PRELOAD_LIBRARIES=$VAL ;;
 						"help"              ) USAGE "print_doc" ;;
 						"version"           ) print_version ;;
 						* ) LOG_MSG "[ERROR]:-Unknown option --$NAME" 1; USAGE ;;

--- a/gpMgmt/bin/lib/gp_bash_functions.sh
+++ b/gpMgmt/bin/lib/gp_bash_functions.sh
@@ -161,6 +161,7 @@ DEFAULTDB=template1
 
 DEFAULT_CHK_PT_SEG=8
 DEFAULT_QD_MAX_CONNECT=250
+DEFAULT_SHARED_PRELOAD_LIBRARIES=""
 QE_CONNECT_FACTOR=3
 # DEFAULT_BUFFERS sets the default shared_buffers unless overridden by '-b'.
 # It applies to the coordinator db and segment dbs.  Specify either the number of

--- a/gpMgmt/bin/lib/gpcreateseg.sh
+++ b/gpMgmt/bin/lib/gpcreateseg.sh
@@ -100,9 +100,7 @@ CREATE_QES_PRIMARY () {
     cmd="$cmd $LC_ALL_SETTINGS"
     cmd="$cmd --max_connections=$QE_MAX_CONNECT"
     cmd="$cmd --shared_buffers=$QE_SHARED_BUFFERS"
-    if [ x"$GP_PRELOAD_LIBRARIES" != x"" ]; then
-        cmd="$cmd --preload-libraries=$GP_PRELOAD_LIBRARIES"
-    fi
+    cmd="$cmd --shared-preload-libraries=$SHARED_PRELOAD_LIBRARIES"
     if [ x"$HEAP_CHECKSUM" == x"on" ]; then
         cmd="$cmd --data-checksums"
     fi

--- a/src/backend/utils/init/miscinit.c
+++ b/src/backend/utils/init/miscinit.c
@@ -1688,17 +1688,6 @@ process_shared_preload_libraries(void)
 {
 	process_shared_preload_libraries_in_progress = true;
 
-	if ((shared_preload_libraries_string == NULL || strlen(shared_preload_libraries_string) == 0)
-		&& (IsBootstrapProcessingMode() || IsInitProcessingMode()))
-	{
-		/*
-		 * if we are in init or bootstrap mode. postgresql.conf does not exists yet.
-		 * try to load libraries from os environment
-		 */
-		char * const env_preload = getenv("GP_PRELOAD_LIBRARIES");
-		load_libraries(env_preload, "GP_PRELOAD_LIBRARIES", false);
-	}
-
 	load_libraries(shared_preload_libraries_string,
 				   "shared_preload_libraries",
 				   false);

--- a/src/bin/initdb/initdb.c
+++ b/src/bin/initdb/initdb.c
@@ -181,6 +181,7 @@ static int	n_connections = 0;
 static int	n_buffers = 0;
 static const char *dynamic_shared_memory_type = NULL;
 static const char *default_timezone = NULL;
+static const char *shared_preload_libraries = NULL;
 
 /*
  * Warning messages for authentication methods
@@ -1011,10 +1012,12 @@ test_config_settings(void)
 				 "-c max_connections=%d "
 				 "-c shared_buffers=%d "
 				 "-c dynamic_shared_memory_type=%s "
+				 "-c shared_preload_libraries=%s "
 				 "< \"%s\" > \"%s\" 2>&1",
 				 backend_exec, boot_options,
 				 test_conns, test_buffs,
 				 dynamic_shared_memory_type,
+				 shared_preload_libraries,
 				 DEVNULL, DEVNULL);
 		status = system(cmd);
 		if (status == 0)
@@ -1050,10 +1053,12 @@ test_config_settings(void)
 				 "-c max_connections=%d "
 				 "-c shared_buffers=%d "
 				 "-c dynamic_shared_memory_type=%s "
+				 "-c shared_preload_libraries=%s "
 				 "< \"%s\" > \"%s\" 2>&1",
 				 backend_exec, boot_options,
 				 n_connections, test_buffs,
 				 dynamic_shared_memory_type,
+				 shared_preload_libraries,
 				 DEVNULL, DEVNULL);
 		status = system(cmd);
 		if (status == 0)
@@ -1125,6 +1130,9 @@ setup_config(void)
 		snprintf(repltok, sizeof(repltok), "shared_buffers = %dkB",
 				 n_buffers * (BLCKSZ / 1024));
 	conflines = replace_token(conflines, "#shared_buffers = 128MB", repltok);
+
+	snprintf(repltok, sizeof(repltok), "shared_preload_libraries = '%s'", shared_preload_libraries ? shared_preload_libraries : "''");
+	conflines = replace_token(conflines, "#shared_preload_libraries = ''", repltok);
 
 #ifdef HAVE_UNIX_SOCKETS
 	snprintf(repltok, sizeof(repltok), "#unix_socket_directories = '%s'",
@@ -2655,7 +2663,7 @@ usage(const char *progname)
 	printf(_("\nLess commonly used options:\n"));
 	printf(_("  -d, --debug               generate lots of debugging output\n"));
 	printf(_("  -k, --data-checksums      use data page checksums\n"));
-	printf(_("  --preload-libraries       load libraries, same as shared_preload_libraries in postgresql.conf\n"));
+	printf(_("  --shared-preload-libraries load libraries, same as shared_preload_libraries in postgresql.conf\n"));
 	printf(_("  -L DIRECTORY              where to find the input files\n"));
 	printf(_("  -n, --no-clean            do not clean up after errors\n"));
 	printf(_("  -N, --no-sync             do not wait for changes to be written safely to disk\n"));
@@ -3347,7 +3355,7 @@ main(int argc, char *argv[])
 		{"data-checksums", no_argument, NULL, 'k'},
 		{"max_connections", required_argument, NULL, 1001},     /*CDB*/
 		{"shared_buffers", required_argument, NULL, 1003},      /*CDB*/
-		{"preload-libraries", required_argument, NULL, 1004},     /*CDB*/
+		{"shared-preload-libraries", required_argument, NULL, 1004},     /*CDB*/
 		{"allow-group-access", no_argument, NULL, 'g'},
 		{NULL, 0, NULL, 0}
 	};
@@ -3493,7 +3501,7 @@ main(int argc, char *argv[])
 				n_buffers = parse_long(optarg, true, "shared_buffers");
 				break;
 			case 1004:
-				setenv("GP_PRELOAD_LIBRARIES", optarg, true);
+				shared_preload_libraries = pg_strdup(optarg);
 				break;
 			case 12:
 				str_wal_segment_size_mb = pg_strdup(optarg);


### PR DESCRIPTION
Pass the shared_preload_libraries to postgres via `-c` argument.

The postgres executable allows user to pass GUC parameters via the `-c`
argument, e.g.,

```
postgres -c shared_preload_libraries='gp_data_encryption'
```

We can utilize this feature and get rid of code changes in miscinit.c.

Also, when creating cluster with the following command

```
SHARED_PRELOAD_LIBRARIES='gp_data_encryption' make create-demo-cluster
```

The value of `shared_preload_libraries` can be written to `postgresql.conf` automatically.