### PR TITLE
add TDE hook in pg_checksums

### DIFF
--- a/src/bin/pg_checksums/.gitignore
+++ b/src/bin/pg_checksums/.gitignore
@@ -1,3 +1,5 @@
 /pg_checksums
 
 /tmp_check/
+
+frontend_hook.c

--- a/src/bin/pg_checksums/Makefile
+++ b/src/bin/pg_checksums/Makefile
@@ -15,12 +15,15 @@ subdir = src/bin/pg_checksums
 top_builddir = ../../..
 include $(top_builddir)/src/Makefile.global
 
-OBJS= pg_checksums.o $(WIN32RES)
+OBJS= pg_checksums.o $(WIN32RES) frontend_hook.o
 
 all: pg_checksums
 
 pg_checksums: $(OBJS) | submake-libpgport
-	$(CC) $(CFLAGS) $^ $(LDFLAGS) $(LDFLAGS_EX) $(LIBS) -o $@$(X)
+	$(CC) $(CFLAGS) $^ $(LDFLAGS) $(LDFLAGS_EX) $(LIBS) -o $@$(X) -Wl,--dynamic-list=hooks.txt
+
+frontend_hook.c: % : $(top_srcdir)/src/fe_utils/%
+	rm -f $@ && $(LN_S) $< .
 
 install: all installdirs
 	$(INSTALL_PROGRAM) pg_checksums$(X) '$(DESTDIR)$(bindir)/pg_checksums$(X)'

--- a/src/bin/pg_checksums/hooks.txt
+++ b/src/bin/pg_checksums/hooks.txt
@@ -1,0 +1,5 @@
+{
+  pg_*;
+  FrontednHookPgInstallPath;
+  FrontendHookPgDataPath;
+};

--- a/src/bin/pg_checksums/pg_checksums.c
+++ b/src/bin/pg_checksums/pg_checksums.c
@@ -529,7 +529,7 @@ main(int argc, char *argv[])
 				break;
 			case 'D':
 				DataDir = optarg;
-				strcpy(FrontendHookPgDataPath, optarg);
+				strncpy(FrontendHookPgDataPath, optarg, MAX_ARG_STRLEN);
 				break;
 			case 'P':
 				showprogress = true;

--- a/src/bin/pg_checksums/pg_checksums.c
+++ b/src/bin/pg_checksums/pg_checksums.c
@@ -90,8 +90,6 @@ usage(void)
 	printf(_("  -P, --progress           show progress information\n"));
 	printf(_("  -v, --verbose            output verbose messages\n"));
 	printf(_("  -V, --version            output version information, then exit\n"));
-	printf(_("      --installdir         the postgresql installdir\n"));
-	printf(_("      --dlopen             the extension to load\n"));
 	printf(_("  -?, --help               show this help, then exit\n"));
 	printf(_("\nIf no data directory (DATADIR) is specified, "
 			 "the environment variable PGDATA\nis used.\n\n"));
@@ -472,8 +470,6 @@ main(int argc, char *argv[])
 		{"no-sync", no_argument, NULL, 'N'},
 		{"progress", no_argument, NULL, 'P'},
 		{"verbose", no_argument, NULL, 'v'},
-		{"installdir", required_argument, NULL, 'I'},
-		{"dlopen", required_argument, NULL, 'E'},
 		{NULL, 0, NULL, 0}
 	};
 
@@ -533,12 +529,6 @@ main(int argc, char *argv[])
 				break;
 			case 'P':
 				showprogress = true;
-				break;
-			case 'I':
-				strlcpy(FrontednHookPgInstallPath, optarg, MAXPGPATH);
-				break;
-			case 'E':
-				frontend_load_library(optarg);
 				break;
 			default:
 				fprintf(stderr, _("Try \"%s --help\" for more information.\n"), progname);

--- a/src/bin/pg_checksums/pg_checksums.c
+++ b/src/bin/pg_checksums/pg_checksums.c
@@ -535,7 +535,7 @@ main(int argc, char *argv[])
 				showprogress = true;
 				break;
 			case 'I':
-				strcpy(FrontednHookPgInstallPath, optarg);
+				strlcpy(FrontednHookPgInstallPath, optarg, MAXPGPATH);
 				break;
 			case 'E':
 				frontend_load_library(optarg);
@@ -563,7 +563,7 @@ main(int argc, char *argv[])
 			exit(1);
 		}
 
-		strcpy(FrontendHookPgDataPath, DataDir);
+		strlcpy(FrontendHookPgDataPath, DataDir, MAXPGPATH);
 	}
 
 	/* Complain if any arguments remain */

--- a/src/bin/pg_checksums/pg_checksums.c
+++ b/src/bin/pg_checksums/pg_checksums.c
@@ -529,7 +529,7 @@ main(int argc, char *argv[])
 				break;
 			case 'D':
 				DataDir = optarg;
-				strncpy(FrontendHookPgDataPath, optarg, MAX_ARG_STRLEN);
+				strlcpy(FrontendHookPgDataPath, optarg, MAXPGPATH);
 				break;
 			case 'P':
 				showprogress = true;

--- a/src/include/fe_utils/pg_checksums_hook.h
+++ b/src/include/fe_utils/pg_checksums_hook.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "c.h"
+
+/*
+ * hook after file read in pg_checksums.
+ * the size of buf is BLKSZ, and offset is aligned with BLKSZ. the extension will modify the buffer
+ */
+typedef void (*pg_checksums_hook_after_read_type)(const char *fname, size_t offset, char *buf);
+extern PGDLLIMPORT pg_checksums_hook_after_read_type pg_checksums_hook_after_read;
+
+/*
+ * hook before file write in pg_checksums.
+ * the size of buf is BLKSZ, and offset is aligned with BLKSZ. the extension will modify the buffer
+ */
+typedef void (*pg_checksums_hook_before_write_type)(const char *fname, size_t offset, char *buf);
+extern PGDLLIMPORT pg_checksums_hook_before_write_type pg_checksums_hook_before_write;


### PR DESCRIPTION
pg_checksums will read and write file directly. run pg_checksums on TDE enabled server will emit a checksum corrupted error. and if with --enable pg_checksums will write data to file, this will cause a checksum corruption.

Add hook in pg_checksums, so the TDE extension can use this hook to encrypt or decrypt data.
